### PR TITLE
修正了Zsh配置文件中的克隆命令

### DIFF
--- a/Linux/zsh_config.md
+++ b/Linux/zsh_config.md
@@ -22,8 +22,8 @@ sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.
 ```bash
 # Assuming you have git installed
 # If not, simply do "sudo yum install git -y"
-git clone https://github.com/zsh-users/zsh-syntax-highlighting.git${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
-git clone https://github.com/zsh-users/zsh-autosuggestions${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
+git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
+git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
 # And then add them to "~/.zshrc" file
 plugins=(git zsh-autosuggestions zsh-syntax-highlighting)
 ```
@@ -31,7 +31,7 @@ plugins=(git zsh-autosuggestions zsh-syntax-highlighting)
 ## powerlevel10k
 
 ```bash
-git clone --depth=1 https://github.com/romkatv/powerlevel10k.git${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k
+git clone --depth=1 https://github.com/romkatv/powerlevel10k.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k
 ```
 
 And then add `ZSH_THEME="powerlevel10k/powerlevel10k"` to `~/.zshrc`.


### PR DESCRIPTION
- 修正了zsh-syntax-highlighting插件的克隆命令空格问题，确保命令正确执行
- 调整了zsh-autosuggestions插件的克隆命令，修正路径拼接错误
- 纠正了powerlevel10k主题的克隆命令格式，避免路径问题确保能够成功克隆