### PR TITLE
Fix homebrew tcl-tk@8 download failure

### DIFF
--- a/Linux/Homebrew_tcl-tk_download_fix.md
+++ b/Linux/Homebrew_tcl-tk_download_fix.md
@@ -1,0 +1,130 @@
+# 成功解决 Homebrew tcl-tk@8 SourceForge 下载失败的完整方案
+
+## 问题描述
+
+在使用 Homebrew 安装 tcl-tk@8 时遇到 SourceForge 下载失败的问题，特别是在非标准路径安装 Homebrew 的情况下。
+
+### 问题诊断
+
+- **根本原因**：SourceForge 的 tcllib-2.0.tar.xz 下载连接超时
+- **加重因素**：非标准 Homebrew 路径导致必须从源码编译
+- **隐藏问题**：API 缓存机制覆盖本地 formula 修改
+
+## 解决步骤
+
+### 1. 确认问题源头
+
+验证网络连接问题：
+
+```bash
+# 验证网络连接问题
+curl -L -o /tmp/test.tar.xz https://downloads.sourceforge.net/project/tcllib/tcllib/2.0/tcllib-2.0.tar.xz
+# 结果：连接超时或文件过小（HTML 错误页面）
+```
+
+### 2. 寻找替代下载源
+
+使用 GitHub 官方镜像作为替代：
+
+```bash
+# GitHub 官方镜像下载成功
+curl -L -o /tmp/tcllib-2-0.tar.gz https://github.com/tcltk/tcllib/archive/refs/tags/tcllib-2-0.tar.gz
+sha256sum /tmp/tcllib-2-0.tar.gz  
+# 获得：c239f54cedc2fc11eb9fd5a7bbf2df1e12965937cd7fd1110e17383ec8f5e632
+```
+
+### 3. 清理 API 缓存并强制本地模式
+
+```bash
+# 终止所有 brew 进程
+pkill -f brew
+
+# 清理 API 缓存
+rm -rf ~/.cache/Homebrew/api-source/
+
+# 设置环境变量禁用自动更新和 API 模式
+export HOMEBREW_NO_AUTO_UPDATE=1
+export HOMEBREW_NO_INSTALL_FROM_API=1
+```
+
+### 4. 编辑正确位置的 formula
+
+**关键点**：安装后 formula 位置会发生变化
+
+```bash
+# 编辑实际使用的 formula 文件
+nano /home/jie/homebrew/Library/Taps/homebrew/homebrew-core/Formula/t/tcl-tk@8.rb
+```
+
+修改 tcllib resource 部分：
+
+```ruby
+resource "tcllib" do
+  url "https://github.com/tcltk/tcllib/archive/refs/tags/tcllib-2-0.tar.gz"
+  sha256 "c239f54cedc2fc11eb9fd5a7bbf2df1e12965937cd7fd1110e17383ec8f5e632"
+end
+```
+
+### 5. 重新安装
+
+```bash
+brew install tcl-tk@8
+```
+
+## 关键经验总结
+
+### 技术要点
+
+1. **下载源替代**：SourceForge 连接问题广泛存在，GitHub 是可靠的替代源
+2. **编译路径**：非标准 Homebrew 路径需要从源码编译所有依赖
+3. **缓存机制**：API 缓存会覆盖本地修改，需要禁用或清理
+4. **文件位置**：Formula 文件位置在 `brew tap` 后会发生变化
+
+### 调试方法
+
+- 使用 `--verbose --debug` 参数查看详细输出
+- 检查实际的 curl 命令和下载 URL
+- 验证文件大小判断是否下载成功（错误页面通常很小）
+- 追踪 formula 加载路径确定编辑位置
+
+### 避免陷阱
+
+1. **不要运行 `brew update`**：会覆盖本地修改
+2. **确认编辑位置**：确保编辑的是实际使用的 formula 文件
+3. **SHA256 验证**：值必须与实际下载文件匹配
+4. **环境变量生效**：设置需要在同一终端会话中生效
+
+## 通用应用
+
+这个解决方案是处理类似 Homebrew 下载失败问题的通用方法：
+
+1. **识别下载失败**：通过 verbose 输出或手动测试 URL
+2. **寻找替代源**：GitHub、官方镜像、CDN 等
+3. **修改 formula**：更新 URL 和 SHA256
+4. **绕过缓存**：使用本地 formula 而非 API
+
+## 相关命令速查
+
+```bash
+# 查看 Homebrew 配置
+brew config
+
+# 查看 formula 位置
+brew --repo homebrew/core
+
+# 清理下载缓存
+rm -rf ~/Library/Caches/Homebrew/downloads/*
+
+# 调试模式安装
+brew install --verbose --debug <package>
+
+# 查看 formula 内容
+brew cat <package>
+
+# 编辑 formula
+brew edit <package>
+```
+
+## 标签
+
+#homebrew #troubleshooting #network #sourceforge #github #formula #cache #linux #macos


### PR DESCRIPTION
Add a new document detailing a comprehensive solution for Homebrew `tcl-tk@8` SourceForge download failures.

This solution addresses common Homebrew installation issues, specifically SourceForge download timeouts, by providing steps to use alternative download sources, manage Homebrew's API cache, and correctly modify formula files, especially for non-standard Homebrew installations.

---
<a href="https://cursor.com/background-agent?bcId=bc-97f51514-aba2-43d2-9b8f-c8aab8df0a6b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-97f51514-aba2-43d2-9b8f-c8aab8df0a6b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Sourcery 总结

添加一份全面的故障排除指南，用于解决在使用 Homebrew 安装 tcl-tk@8 时 SourceForge 下载失败的问题。

文档：
- 引入 `Linux/Homebrew_tcl-tk_download_fix.md`，其中记录了诊断网络超时、使用替代下载源、清除 Homebrew 的 API 缓存、编辑本地公式以及重新安装的步骤。
- 包含关键的故障排除技巧、命令参考以及通用的最佳实践，用于处理 Homebrew 下载和公式问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a comprehensive troubleshooting guide for fixing SourceForge download failures when installing tcl-tk@8 via Homebrew.

Documentation:
- Introduce Linux/Homebrew_tcl-tk_download_fix.md documenting steps to diagnose network timeouts, use alternative download sources, clear Homebrew’s API cache, edit the local formula, and reinstall.
- Include key troubleshooting tips, command references, and general best practices for handling Homebrew download and formula issues.

</details>